### PR TITLE
Update LAMMPS to 27 Oct 2021

### DIFF
--- a/.ci_support/linux_64_mpimpichpython3.10.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.10.____cpython.yaml
@@ -23,13 +23,13 @@ fortran_compiler_version:
 hdf5:
 - 1.12.1
 libblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcurl:
 - '7'
 liblapack:
-- 3.8 *netlib
+- 3.9 *netlib
 libpng:
 - '1.6'
 mpi:

--- a/.ci_support/linux_64_mpimpichpython3.7.____73_pypy.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.7.____73_pypy.yaml
@@ -23,13 +23,13 @@ fortran_compiler_version:
 hdf5:
 - 1.12.1
 libblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcurl:
 - '7'
 liblapack:
-- 3.8 *netlib
+- 3.9 *netlib
 libpng:
 - '1.6'
 mpi:

--- a/.ci_support/linux_64_mpimpichpython3.7.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.7.____cpython.yaml
@@ -23,13 +23,13 @@ fortran_compiler_version:
 hdf5:
 - 1.12.1
 libblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcurl:
 - '7'
 liblapack:
-- 3.8 *netlib
+- 3.9 *netlib
 libpng:
 - '1.6'
 mpi:

--- a/.ci_support/linux_64_mpimpichpython3.8.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.8.____cpython.yaml
@@ -23,13 +23,13 @@ fortran_compiler_version:
 hdf5:
 - 1.12.1
 libblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcurl:
 - '7'
 liblapack:
-- 3.8 *netlib
+- 3.9 *netlib
 libpng:
 - '1.6'
 mpi:

--- a/.ci_support/linux_64_mpimpichpython3.9.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.9.____cpython.yaml
@@ -23,13 +23,13 @@ fortran_compiler_version:
 hdf5:
 - 1.12.1
 libblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcurl:
 - '7'
 liblapack:
-- 3.8 *netlib
+- 3.9 *netlib
 libpng:
 - '1.6'
 mpi:

--- a/.ci_support/linux_64_mpiopenmpipython3.10.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.10.____cpython.yaml
@@ -23,13 +23,13 @@ fortran_compiler_version:
 hdf5:
 - 1.12.1
 libblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcurl:
 - '7'
 liblapack:
-- 3.8 *netlib
+- 3.9 *netlib
 libpng:
 - '1.6'
 mpi:

--- a/.ci_support/linux_64_mpiopenmpipython3.7.____73_pypy.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.7.____73_pypy.yaml
@@ -23,13 +23,13 @@ fortran_compiler_version:
 hdf5:
 - 1.12.1
 libblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcurl:
 - '7'
 liblapack:
-- 3.8 *netlib
+- 3.9 *netlib
 libpng:
 - '1.6'
 mpi:

--- a/.ci_support/linux_64_mpiopenmpipython3.7.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.7.____cpython.yaml
@@ -23,13 +23,13 @@ fortran_compiler_version:
 hdf5:
 - 1.12.1
 libblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcurl:
 - '7'
 liblapack:
-- 3.8 *netlib
+- 3.9 *netlib
 libpng:
 - '1.6'
 mpi:

--- a/.ci_support/linux_64_mpiopenmpipython3.8.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.8.____cpython.yaml
@@ -23,13 +23,13 @@ fortran_compiler_version:
 hdf5:
 - 1.12.1
 libblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcurl:
 - '7'
 liblapack:
-- 3.8 *netlib
+- 3.9 *netlib
 libpng:
 - '1.6'
 mpi:

--- a/.ci_support/linux_64_mpiopenmpipython3.9.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.9.____cpython.yaml
@@ -23,13 +23,13 @@ fortran_compiler_version:
 hdf5:
 - 1.12.1
 libblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcurl:
 - '7'
 liblapack:
-- 3.8 *netlib
+- 3.9 *netlib
 libpng:
 - '1.6'
 mpi:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
-{% set build = 3 %}
+{% set build = 0 %}
 {% set name = "lammps" %}
-{% set version = "stable_29Sep2021" %}
-{% set sha256 = "2dff656cb21fd9a6d46c818741c99d400cfb1b12102604844663b655fb2f893d" %}
+{% set version = "patch_27Oct2021" %}
+{% set sha256 = "c06f682fcf9d5921ca90c857a104e90fba0fe65decaac9732745e4da49281938" %}
 {% set date = datetime.datetime.strptime(version.split('_')[1], "%d%b%Y") %}
 {% set conda_version = "{:%Y.%m.%d}".format(date) %}
 


### PR DESCRIPTION
This will update the meta.yml to update LAMMPS to [27 Oct 2021](https://github.com/lammps/lammps/releases/tag/patch_27Oct2021) release. This release adds the ML-PACE multispecies potential, among many updates to the stable 29 Sept version.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
